### PR TITLE
Add MIT license and gitignore .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ desktop.ini
 # IDE
 .vscode/
 .idea/
+.claude/
 *.swp
 *.swo
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Joseph Tsai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- Add MIT LICENSE file for open source clarity
- Add `.claude/` to `.gitignore` to prevent committing Claude memory files

## Repo housekeeping also done (no PR needed)
- Disabled empty wiki
- Added repo topics: color-palette, pantone, design-tools, color-matching, html-tool, brand-design
- Cleaned up stale git stash

🤖 Generated with [Claude Code](https://claude.com/claude-code)