### PR TITLE
Update CLAUDE.md: one Fixes per line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,8 @@
 
 - Do NOT include `Co-Authored-By` lines in commit messages.
 - When creating a pull request that fixes issues, always include `Fixes #X` (or `Closes #X`) in the **PR description body** (not just in commit messages), so GitHub auto-closes the issues on merge.
-- Link related issues in the PR body with their title for context, e.g.:
+- Put each `Fixes` on its own line (comma-separated may not auto-close all issues):
   ```
   Fixes #5 — Bug: Pantone type filter ignored when searching by hex value
+  Fixes #6 — Bug: Toast messages can stack and interfere
   ```


### PR DESCRIPTION
## Summary
- Update rule: put each Fixes #X on its own line instead of comma-separated, to ensure GitHub auto-closes all referenced issues on merge