### PR TITLE
Fix performance: debounce slider saves & pre-compute Pantone Lab

### DIFF
--- a/brand-palette-pantone/index.html
+++ b/brand-palette-pantone/index.html
@@ -2567,14 +2567,21 @@
             });
         });
 
+        let sliderSaveTimeout;
         document.getElementById('saturationSlider').addEventListener('input', (e) => {
             document.getElementById('satValue').textContent = `${e.target.value}%`;
-            try { localStorage.setItem('bpg-saturation', e.target.value); } catch(e2) {}
+            clearTimeout(sliderSaveTimeout);
+            sliderSaveTimeout = setTimeout(() => {
+                try { localStorage.setItem('bpg-saturation', e.target.value); } catch(e2) {}
+            }, 500);
         });
 
         document.getElementById('brightnessSlider').addEventListener('input', (e) => {
             document.getElementById('brightValue').textContent = `${e.target.value}%`;
-            try { localStorage.setItem('bpg-brightness', e.target.value); } catch(e2) {}
+            clearTimeout(sliderSaveTimeout);
+            sliderSaveTimeout = setTimeout(() => {
+                try { localStorage.setItem('bpg-brightness', e.target.value); } catch(e2) {}
+            }, 500);
         });
 
         document.getElementById('generateBtn').addEventListener('click', () => {
@@ -3564,6 +3571,14 @@
             }
         })();
         renderPopularColors();
+
+        // Pre-compute Pantone Lab values during idle time for faster matching
+        (window.requestIdleCallback || setTimeout)(() => {
+            allPantone.forEach(p => {
+                const rgb = hexToRgb(p.hex);
+                pantoneLabCache.set(p.hex, rgbToLab(rgb.r, rgb.g, rgb.b));
+            });
+        });
     </script>
     <!-- Floating comparison overlay (separate layer, fully opaque) -->
     <div id="compareOverlay" class="pantone-compare-overlay"></div>


### PR DESCRIPTION
## Summary
- Debounce saturation/brightness slider `localStorage.setItem()` calls by 500ms to avoid excessive writes on every `input` event, while keeping the visual UI update immediate.
- Pre-compute all Pantone Lab values using `requestIdleCallback` (with `setTimeout` fallback) after page load, instead of computing them lazily on first search.

Fixes #39
Fixes #40

## Test plan
- [ ] Move saturation and brightness sliders rapidly; confirm the UI updates immediately but `localStorage` is only written after ~500ms of inactivity (check via DevTools Application tab).
- [ ] Load the page and verify Pantone Lab cache is populated (e.g., log `pantoneLabCache.size` after idle callback fires).
- [ ] Perform a Pantone color search and confirm results still display correctly and quickly.

https://claude.ai/code/session_017PTSV9A5SKJFpPzCrHqaXz