### PR TITLE
Fix: Pre-compute Pantone Lab values on page load

### DIFF
--- a/brand-palette-pantone/index.html
+++ b/brand-palette-pantone/index.html
@@ -3592,6 +3592,14 @@
             }
         })();
         renderPopularColors();
+
+        // Pre-compute Pantone Lab values during idle time for faster matching
+        (window.requestIdleCallback || setTimeout)(() => {
+            allPantone.forEach(p => {
+                const rgb = hexToRgb(p.hex);
+                pantoneLabCache.set(p.hex, rgbToLab(rgb.r, rgb.g, rgb.b));
+            });
+        });
     </script>
     <!-- Floating comparison overlay (separate layer, fully opaque) -->
     <div id="compareOverlay" class="pantone-compare-overlay"></div>


### PR DESCRIPTION
## Summary

- Pre-compute all Pantone Lab values during browser idle time using `requestIdleCallback` (with `setTimeout` fallback), eliminating cold-start latency on first search.

## Test plan

- [x] Load the page and verify Pantone colors render correctly
- [x] Perform a hex-based color search immediately after page load and confirm no noticeable delay
- [x] Verify `pantoneLabCache` is populated after idle callback fires (check via DevTools console)

Fixes #40

https://claude.ai/code/session_017PTSV9A5SKJFpPzCrHqaXz