### PR TITLE
Fix: Color contrast on dynamic color family buttons

### DIFF
--- a/brand-palette-pantone/index.html
+++ b/brand-palette-pantone/index.html
@@ -2505,7 +2505,7 @@
             if (!container) return;
             
             container.innerHTML = families.map(f => `
-                <div class="color-family-btn" style="background: ${f.color}" title="${f.name}" data-search="${f.search}">
+                <div class="color-family-btn" style="background: ${f.color}; color: ${getContrastColor(f.color)}" title="${f.name}" data-search="${f.search}">
                     <span>${f.name}</span>
                 </div>
             `).join('');


### PR DESCRIPTION
## Summary
- Add dynamic text color to color family buttons using `getContrastColor()` so button labels are readable against their background color.

## Test plan
- [ ] Verify color family buttons display legible text on both light and dark background colors
- [ ] Confirm `getContrastColor()` returns white for dark backgrounds and dark color for light backgrounds

Fixes #33 — Color contrast on dynamic color family buttons

https://claude.ai/code/session_017PTSV9A5SKJFpPzCrHqaXz