### PR TITLE
Fix: Debounce slider localStorage writes

### DIFF
--- a/brand-palette-pantone/index.html
+++ b/brand-palette-pantone/index.html
@@ -2591,14 +2591,21 @@
             });
         });
 
+        let sliderSaveTimeout;
         document.getElementById('saturationSlider').addEventListener('input', (e) => {
             document.getElementById('satValue').textContent = `${e.target.value}%`;
-            try { localStorage.setItem('bpg-saturation', e.target.value); } catch(e2) {}
+            clearTimeout(sliderSaveTimeout);
+            sliderSaveTimeout = setTimeout(() => {
+                try { localStorage.setItem('bpg-saturation', e.target.value); } catch(e2) {}
+            }, 500);
         });
 
         document.getElementById('brightnessSlider').addEventListener('input', (e) => {
             document.getElementById('brightValue').textContent = `${e.target.value}%`;
-            try { localStorage.setItem('bpg-brightness', e.target.value); } catch(e2) {}
+            clearTimeout(sliderSaveTimeout);
+            sliderSaveTimeout = setTimeout(() => {
+                try { localStorage.setItem('bpg-brightness', e.target.value); } catch(e2) {}
+            }, 500);
         });
 
         document.getElementById('generateBtn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Debounce `localStorage.setItem()` calls in the saturation and brightness slider `input` event listeners with a shared 500ms timeout
- Visual text updates remain immediate for responsive UI feedback
- Reduces excessive localStorage writes during rapid slider dragging

Fixes #39

https://claude.ai/code/session_017PTSV9A5SKJFpPzCrHqaXz