### PR TITLE
Fix: Add focus trap to PDF export panel

### DIFF
--- a/brand-palette-pantone/index.html
+++ b/brand-palette-pantone/index.html
@@ -3498,15 +3498,59 @@
 
         // PDF Section Panel logic
         const pdfPanel = document.getElementById('pdfSectionPanel');
-        document.getElementById('exportPdfBtn').addEventListener('click', (e) => {
+        const exportPdfBtn = document.getElementById('exportPdfBtn');
+
+        function pdfPanelKeyHandler(e) {
+            const focusable = [...pdfPanel.querySelectorAll('input, button')];
+            if (!focusable.length) return;
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                closePdfPanel();
+                return;
+            }
+            if (e.key === 'Tab') {
+                const first = focusable[0];
+                const last = focusable[focusable.length - 1];
+                if (e.shiftKey) {
+                    if (document.activeElement === first) {
+                        e.preventDefault();
+                        last.focus();
+                    }
+                } else {
+                    if (document.activeElement === last) {
+                        e.preventDefault();
+                        first.focus();
+                    }
+                }
+            }
+        }
+
+        function openPdfPanel() {
+            pdfPanel.classList.add('show');
+            const focusable = pdfPanel.querySelectorAll('input, button');
+            if (focusable.length) focusable[0].focus();
+            pdfPanel.addEventListener('keydown', pdfPanelKeyHandler);
+        }
+
+        function closePdfPanel() {
+            pdfPanel.classList.remove('show');
+            pdfPanel.removeEventListener('keydown', pdfPanelKeyHandler);
+            exportPdfBtn.focus();
+        }
+
+        exportPdfBtn.addEventListener('click', (e) => {
             e.stopPropagation();
-            pdfPanel.classList.toggle('show');
+            if (pdfPanel.classList.contains('show')) {
+                closePdfPanel();
+            } else {
+                openPdfPanel();
+            }
         });
 
         // Close panel when clicking outside
         document.addEventListener('click', (e) => {
             if (!e.target.closest('.pdf-export-wrap')) {
-                pdfPanel.classList.remove('show');
+                closePdfPanel();
             }
         });
 
@@ -3530,7 +3574,7 @@
             const btn = document.getElementById('pdfGenerateBtn');
             btn.disabled = true;
             btn.textContent = 'Generating...';
-            pdfPanel.classList.remove('show');
+            closePdfPanel();
 
             setTimeout(() => {
                 try {


### PR DESCRIPTION
## Summary
- Add `openPdfPanel()` / `closePdfPanel()` functions that manage focus trapping within the PDF section selection panel
- Trap Tab/Shift+Tab cycling among focusable elements (inputs and buttons) inside the panel
- Close the panel and restore focus to the export button on Escape key
- Restore focus to `exportPdfBtn` when the panel is closed by any means (click outside, generate, toggle)

Fixes #34

## Test plan
- [ ] Open the PDF export panel and verify the first focusable element receives focus
- [ ] Press Tab repeatedly and confirm focus cycles within the panel without escaping
- [ ] Press Shift+Tab at the first element and confirm focus wraps to the last element
- [ ] Press Escape and confirm the panel closes and focus returns to the export button
- [ ] Click outside the panel and confirm it closes with focus restored
- [ ] Click "Generate PDF" and confirm the panel closes properly

https://claude.ai/code/session_017PTSV9A5SKJFpPzCrHqaXz