### PR TITLE
fix: critical copyToClipboard recursion bug & ARIA overlay

### DIFF
--- a/brand-palette-pantone/index.html
+++ b/brand-palette-pantone/index.html
@@ -1549,7 +1549,7 @@
 
         async function copyToClipboard(text) {
             try {
-                await copyToClipboard(text);
+                await navigator.clipboard.writeText(text);
             } catch(e) {
                 try {
                     const ta = document.createElement('textarea');
@@ -3594,7 +3594,7 @@
         renderPopularColors();
     </script>
     <!-- Floating comparison overlay (separate layer, fully opaque) -->
-    <div id="compareOverlay" class="pantone-compare-overlay"></div>
+    <div id="compareOverlay" class="pantone-compare-overlay" role="dialog" aria-modal="false" aria-label="Pantone color comparison"></div>
     <div style="position: fixed; bottom: 8px; left: 12px; font-size: 0.7rem; color: var(--text-dim); display: flex; align-items: center; gap: 8px;">
         <span style="pointer-events: none;">v3.1</span>
         <a href="https://github.com/Joseph-tsai415/Yiling-Art" target="_blank" rel="noopener" style="color: var(--text-muted); text-decoration: none; opacity: 0.7; transition: opacity 0.2s;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.7'">GitHub</a>


### PR DESCRIPTION
## Summary

- **Critical bug fix:** `copyToClipboard()` was calling itself recursively instead of `navigator.clipboard.writeText()`, causing a stack overflow crash on every copy action (hex values, CSS variables, Pantone data export — all broken)
- **Accessibility:** Added `role="dialog"` and `aria-label` to the Pantone comparison overlay for screen reader support

## Test plan

- [ ] Click any "copy" button (hex value, CSS variables, Pantone list) and verify text is copied to clipboard
- [ ] Hover over a Pantone match card and verify the comparison overlay appears with proper content
- [ ] Test with a screen reader to confirm the overlay is announced as a dialog

https://claude.ai/code/session_01E4sKXjurifZ5pUBRxSQuqU