### PR TITLE
Fix release versioning: auto-inject version from git tag

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -22,6 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Inject version from latest git tag
+        run: |
+          VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+          echo "Injecting version: $VERSION"
+          sed -i "s/__APP_VERSION__/$VERSION/g" brand-palette-pantone/index.html
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/brand-palette-pantone/index.html
+++ b/brand-palette-pantone/index.html
@@ -3695,7 +3695,7 @@
     <!-- Floating comparison overlay (separate layer, fully opaque) -->
     <div id="compareOverlay" class="pantone-compare-overlay" role="dialog" aria-modal="false" aria-label="Pantone color comparison"></div>
     <div style="position: fixed; bottom: 8px; left: 12px; font-size: 0.7rem; color: var(--text-dim); display: flex; align-items: center; gap: 8px;">
-        <span style="pointer-events: none;">v3.1</span>
+        <span style="pointer-events: none;">__APP_VERSION__</span>
         <a href="https://github.com/Joseph-tsai415/Yiling-Art" target="_blank" rel="noopener" style="color: var(--text-muted); text-decoration: none; opacity: 0.7; transition: opacity 0.2s;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.7'">GitHub</a>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- Replace hardcoded `v3.1` version string in `index.html` with `__APP_VERSION__` placeholder
- Update Pages deploy workflow to fetch full git history and inject the latest git tag as the version
- Now each new tagged release automatically shows the correct version on the deployed site

## How it works
1. `index.html` contains `__APP_VERSION__` placeholder instead of a hardcoded version
2. During deploy, the workflow runs `git describe --tags --abbrev=0` to get the latest tag
3. `sed` replaces the placeholder with the actual tag (e.g., `v3.2`)
4. Falls back to `dev` if no tags exist

## Release workflow going forward
1. Merge feature PRs into `dev`
2. Create release PR from `dev` → `master`
3. After merge, create a new git tag (e.g., `v3.2`) and GitHub release
4. The Pages deploy will automatically pick up the new tag and display it

## Test plan
- [ ] Verify `__APP_VERSION__` placeholder exists in `index.html`
- [ ] Verify deploy workflow has `fetch-depth: 0` and sed injection step
- [ ] After merging and tagging, confirm deployed site shows new version

https://claude.ai/code/session_01QhP2khGkPmsDP4sXBKsakx