### PR TITLE
Release: card-printer template + CMYK PDF

### DIFF
--- a/product-card-printer/index.html
+++ b/product-card-printer/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Product Card Printer — 103×73 mm Cards on A3/A4</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Chocolate+Classical+Sans&display=swap" rel="stylesheet">
     <style>
         :root {
             --bg-gradient-1: #1a1a2e;
@@ -13,15 +16,10 @@
             --text-muted: #888;
             --text-dim: #666;
             --panel-bg: rgba(255, 255, 255, 0.05);
-            --item-bg: rgba(255, 255, 255, 0.05);
-            --item-hover: rgba(255, 255, 255, 0.1);
             --border-subtle: rgba(255, 255, 255, 0.1);
             --border-medium: rgba(255, 255, 255, 0.15);
             --input-bg: rgba(255, 255, 255, 0.08);
             --accent: #4982cf;
-            --card-bg: #ffffff;
-            --card-ink: #1a1a2e;
-            --card-border: #d0d4da;
         }
         :root.light-mode {
             --bg-gradient-1: #f0f2f5;
@@ -31,8 +29,6 @@
             --text-muted: #666;
             --text-dim: #888;
             --panel-bg: rgba(255, 255, 255, 0.92);
-            --item-bg: rgba(0, 0, 0, 0.05);
-            --item-hover: rgba(0, 0, 0, 0.09);
             --border-subtle: rgba(0, 0, 0, 0.1);
             --border-medium: rgba(0, 0, 0, 0.15);
             --input-bg: rgba(0, 0, 0, 0.06);
@@ -59,10 +55,7 @@
             color: var(--text-muted);
             margin-bottom: 6px;
         }
-        header .crumb a {
-            color: var(--text-secondary);
-            text-decoration: none;
-        }
+        header .crumb a { color: var(--text-secondary); text-decoration: none; }
         header .crumb a:hover { color: var(--text-primary); }
         header h1 {
             font-size: clamp(1.5rem, 3vw, 2rem);
@@ -70,10 +63,7 @@
             margin-bottom: 6px;
             letter-spacing: -0.01em;
         }
-        header p {
-            color: var(--text-secondary);
-            font-size: 0.95rem;
-        }
+        header p { color: var(--text-secondary); font-size: 0.95rem; }
 
         .panel {
             background: var(--panel-bg);
@@ -148,6 +138,15 @@
         }
         .status.error { color: #f87171; }
 
+        .field-map {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 10px;
+            margin-top: 10px;
+            font-size: 0.85rem;
+        }
+        .field-map label { color: var(--text-muted); align-self: center; }
+
         .preview-meta {
             display: flex;
             justify-content: space-between;
@@ -162,15 +161,15 @@
         }
         .preview-meta .summary strong { color: var(--text-primary); }
 
-        .pages { display: flex; flex-direction: column; gap: 24px; }
+        .pages { display: flex; flex-direction: column; gap: 24px; align-items: center; }
 
         .page {
             background: #fff;
             border-radius: 4px;
             box-shadow: 0 4px 24px rgba(0,0,0,0.25);
             position: relative;
-            margin: 0 auto;
             overflow: hidden;
+            transform-origin: top left;
         }
         .page-label {
             position: absolute;
@@ -178,53 +177,51 @@
             left: 0;
             font-size: 0.75rem;
             color: var(--text-muted);
+            transform: scale(calc(1 / var(--preview-scale, 1)));
+            transform-origin: top left;
         }
 
+        /* ---------- Card template ---------- */
         .card {
             position: absolute;
-            background: var(--card-bg);
-            color: var(--card-ink);
-            border: 0.3mm solid var(--card-border);
-            padding: 3mm 4mm;
+            background: #fff;
+            color: #fbf6ed;
             overflow: hidden;
-            font-family: 'Segoe UI', Arial, sans-serif;
-            display: flex;
-            flex-direction: column;
-        }
-        .card .title {
-            font-size: 4.2mm;
-            font-weight: 700;
+            /* Only Chocolate Classical Sans, then a clearly different serif fallback so
+               it's visually obvious if the Google Font has not loaded yet. */
+            font-family: 'Chocolate Classical Sans', serif;
             line-height: 1.15;
-            margin-bottom: 1.5mm;
-            color: var(--card-ink);
         }
-        .card .price {
-            font-size: 5mm;
-            font-weight: 700;
-            color: #b91c1c;
-            margin-bottom: 1.5mm;
+        .card-bg {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            user-select: none;
+            -webkit-user-drag: none;
         }
-        .card .fields {
-            font-size: 2.6mm;
-            line-height: 1.25;
-            color: #444;
-            flex: 1;
-            overflow: hidden;
+        .card-text {
+            position: absolute;
+            color: #fbf6ed;
+            white-space: pre-wrap;
+            z-index: 2;
         }
-        .card .fields .row-item {
-            margin-bottom: 0.8mm;
+        .card-text.center {
+            left: 0;
+            right: 0;
+            text-align: center;
         }
-        .card .fields .row-item .key {
-            font-weight: 600;
-            color: #1a1a2e;
-        }
-        .card .footer {
-            font-size: 2.2mm;
-            color: #888;
-            border-top: 0.2mm dashed #d0d4da;
-            padding-top: 1mm;
-            margin-top: auto;
-        }
+        /*
+         * All positions measured in mm from the top-left of the card.
+         * Card is 103mm × 73mm.
+         */
+        .card-text.title          { top: 23mm; font-size: 10pt; font-weight: 600; }
+        .card-text.english-title  { top: 30mm; font-size: 10pt; }
+        .card-text.cn-ingredients { top: 42mm; font-size: 9pt;  }
+        .card-text.en-ingredients { top: 49mm; font-size: 9pt;  }
+        .card-text.allergens      { left: 5.5mm; top: 60mm; font-size: 9pt;  text-align: left;  max-width: 70mm; }
+        .card-text.price          { left: 82mm; top: 60mm; font-size: 14pt; font-weight: 700; }
 
         details summary {
             cursor: pointer;
@@ -233,15 +230,6 @@
             margin-bottom: 8px;
         }
         details summary:hover { color: var(--text-primary); }
-
-        .field-map {
-            display: grid;
-            grid-template-columns: 1fr 2fr;
-            gap: 10px;
-            margin-top: 10px;
-            font-size: 0.85rem;
-        }
-        .field-map label { color: var(--text-muted); align-self: center; }
 
         .theme-toggle {
             position: fixed;
@@ -287,6 +275,20 @@
             <p>Upload a CSV of products and lay them out as 103 × 73 mm cards on A3 or A4, ready for printing.</p>
         </header>
 
+        <div id="corsBanner" hidden style="background: rgba(248, 113, 113, 0.1); border: 1px solid rgba(248, 113, 113, 0.4); border-radius: 10px; padding: 14px 18px; margin-bottom: 20px; font-size: 0.85rem; line-height: 1.5;">
+            <strong style="color: #f87171;">S3 bucket needs CORS configured for the background image.</strong>
+            The PDF export reads the background image into a canvas, which requires the host to send <code>Access-Control-Allow-Origin</code>. In the S3 console, open the bucket → <em>Permissions</em> → <em>Cross-origin resource sharing (CORS)</em> and paste:
+            <pre style="margin-top: 8px; padding: 8px 12px; background: rgba(0,0,0,0.25); border-radius: 6px; font-size: 0.8rem; overflow-x: auto;">[
+  {
+    "AllowedHeaders": ["*"],
+    "AllowedMethods": ["GET", "HEAD"],
+    "AllowedOrigins": ["*"],
+    "ExposeHeaders": []
+  }
+]</pre>
+            Save and retry. Preview already works because plain <code>&lt;img&gt;</code> tags don't need CORS — only canvas reads do.
+        </div>
+
         <section class="panel">
             <h2>1. Upload CSV</h2>
             <div class="controls">
@@ -322,15 +324,21 @@
         <section class="panel" id="mappingPanel" hidden>
             <h2>2. Map CSV columns to card fields</h2>
             <p style="font-size: 0.85rem; color: var(--text-muted); margin-bottom: 10px;">
-                Pick which CSV column feeds each card field. Any remaining columns appear in the body as key/value rows.
+                Pick which CSV column feeds each field on the card. Multi-line text in allergens: use a quoted cell with literal line breaks, or write “\n” between lines.
             </p>
             <div class="field-map">
-                <label for="mapTitle">Title</label>
+                <label for="mapTitle">Title (Chinese)</label>
                 <select id="mapTitle"></select>
+                <label for="mapEnglishTitle">Title (English)</label>
+                <select id="mapEnglishTitle"></select>
+                <label for="mapCnIngredients">Ingredients (Chinese)</label>
+                <select id="mapCnIngredients"></select>
+                <label for="mapEnIngredients">Ingredients (English)</label>
+                <select id="mapEnIngredients"></select>
+                <label for="mapAllergens">Allergens</label>
+                <select id="mapAllergens"></select>
                 <label for="mapPrice">Price</label>
                 <select id="mapPrice"></select>
-                <label for="mapFooter">Footer (optional)</label>
-                <select id="mapFooter"></select>
             </div>
         </section>
 
@@ -353,6 +361,13 @@
         const CARD_W_MM = 103;
         const CARD_H_MM = 73;
 
+        // Background image hosted on S3. Bucket must have CORS configured to allow
+        // GET from this site's origin (or *), otherwise the PDF canvas read will be
+        // blocked by the same-origin policy.
+        const BG_URL = 'https://db-doc-tw1.s3.ap-east-2.amazonaws.com/background.png';
+        // Optional: drop a CMYK-encoded JPEG at this URL for fully-CMYK PDFs.
+        const BG_CMYK_URL = 'https://db-doc-tw1.s3.ap-east-2.amazonaws.com/background.cmyk.jpg';
+
         const PAGES = {
             'a4-portrait':  { w: 210, h: 297, label: 'A4 portrait',  jsOrientation: 'p', jsFormat: 'a4' },
             'a4-landscape': { w: 297, h: 210, label: 'A4 landscape', jsOrientation: 'l', jsFormat: 'a4' },
@@ -360,22 +375,49 @@
             'a3-landscape': { w: 420, h: 297, label: 'A3 landscape', jsOrientation: 'l', jsFormat: 'a3' },
         };
 
+        const FONT_FAMILY = 'Chocolate Classical Sans';
+        // Sample of every script we expect on the cards. Used to force Google Fonts
+        // to pull the right unicode-range subsets before we rasterize.
+        const FONT_SAMPLE_TEXT = 'ABC abc 0123 $€ 毛豆梵谷起司 抹茶生巧克力 奶素含乳製品';
+
+        async function ensureFontLoaded() {
+            if (!document.fonts || !document.fonts.load) return;
+            const sizes = ['10pt', '14pt', '9pt'];
+            await Promise.all(sizes.map(size =>
+                document.fonts.load(`${size} "${FONT_FAMILY}"`, FONT_SAMPLE_TEXT)
+            ));
+            await document.fonts.ready;
+        }
+
+        function isFontAvailable() {
+            return !!document.fonts && document.fonts.check(`10pt "${FONT_FAMILY}"`, FONT_SAMPLE_TEXT);
+        }
+
+        const FIELDS = [
+            { id: 'title',          label: 'Title (Chinese)',     selectId: 'mapTitle',          aliases: ['title', 'chinese title', 'name', 'product'] },
+            { id: 'englishTitle',   label: 'Title (English)',     selectId: 'mapEnglishTitle',   aliases: ['english', 'english title'] },
+            { id: 'cnIngredients',  label: 'Ingredients (CN)',    selectId: 'mapCnIngredients',  aliases: ['chinese ingredients', 'ingredients zh', 'ingredients_zh', '材料', '成分'] },
+            { id: 'enIngredients',  label: 'Ingredients (EN)',    selectId: 'mapEnIngredients',  aliases: ['english ingredients', 'ingredients en', 'ingredients_en', 'ingredients'] },
+            { id: 'allergens',      label: 'Allergens',           selectId: 'mapAllergens',      aliases: ['allergen', 'allergens', 'allergy', '過敏'] },
+            { id: 'price',          label: 'Price',               selectId: 'mapPrice',          aliases: ['price', 'cost', '價格'] },
+        ];
+
         const SAMPLE_CSV =
-            'Title,Price,Ingredients,Allergens,Origin\n' +
-            'Tomato Basil Soup,$8.50,"Tomato, basil, cream, garlic, salt","Dairy",Italy\n' +
-            'Pesto Linguine,$12.00,"Linguine, basil, pine nuts, parmesan, olive oil","Wheat, dairy, nuts",Italy\n' +
-            'Caesar Salad,$10.00,"Romaine, parmesan, anchovy, croutons","Wheat, dairy, fish",USA\n' +
-            'Margherita Pizza,$14.50,"Tomato, mozzarella, basil, dough","Wheat, dairy",Italy\n' +
-            'Chocolate Lava Cake,$7.50,"Chocolate, butter, egg, flour, sugar","Egg, dairy, wheat",France\n' +
-            'Iced Matcha Latte,$5.50,"Matcha, milk, ice","Dairy",Japan\n';
+            'Chinese Title,English Title,Chinese Ingredients,English Ingredients,Allergens,Price\n' +
+            '"毛豆梵谷起司巧巴達","Edamame & Van Gogh Cheese Ciabatta","毛豆、梵谷起司","Edamame, Vincent Van Gogh Cheese","奶素Veg\\n含乳製品Contains Dairy","$85"\n' +
+            '"紅藜麥酸種","Red Quinoa Sourdough","紅藜麥、酸種麵粉","Red quinoa, sourdough flour","純素Vegan\\n含麩質Contains Gluten","$78"\n' +
+            '"伯爵茶磅蛋糕","Earl Grey Pound Cake","伯爵茶、奶油、雞蛋","Earl Grey tea, butter, eggs","奶蛋素Lacto-ovo\\n含乳製品Contains Dairy, Egg","$120"\n' +
+            '"南瓜籽全麥","Pumpkin Seed Whole Wheat","南瓜籽、全麥麵粉","Pumpkin seeds, whole wheat flour","純素Vegan\\n含麩質Contains Gluten","$68"\n' +
+            '"莓果可頌","Berry Croissant","綜合莓果、奶油","Mixed berries, butter","奶蛋素Lacto-ovo\\n含乳製品Contains Dairy","$95"\n' +
+            '"抹茶生巧克力","Matcha Raw Chocolate","抹茶、可可、鮮奶油","Matcha, cacao, fresh cream","奶素Veg\\n含乳製品Contains Dairy","$135"\n';
 
         const state = {
             headers: [],
             rows: [],
-            map: { title: 0, price: -1, footer: -1 },
+            map: { title: -1, englishTitle: -1, cnIngredients: -1, enIngredients: -1, allergens: -1, price: -1 },
         };
 
-        // Minimal CSV parser supporting quoted fields and embedded newlines.
+        // Minimal CSV parser: supports quoted fields, embedded newlines, and "" escape.
         function parseCSV(text) {
             const rows = [];
             let field = '';
@@ -405,6 +447,21 @@
             el.classList.toggle('error', !!isError);
         }
 
+        // Convert literal "\n" sequences inside CSV cells into real newlines so allergen
+        // text can be written on a single CSV line.
+        function unescapeNewlines(s) {
+            return String(s || '').replace(/\\n/g, '\n');
+        }
+
+        function findHeaderIndex(headers, aliases) {
+            const lc = headers.map(h => h.toLowerCase().trim());
+            for (const alias of aliases) {
+                const i = lc.findIndex(h => h === alias || h.includes(alias));
+                if (i !== -1) return i;
+            }
+            return -1;
+        }
+
         function ingestCSV(text) {
             const rows = parseCSV(text);
             if (rows.length < 2) {
@@ -414,17 +471,9 @@
             state.headers = rows[0].map(h => h.trim());
             state.rows = rows.slice(1).map(r => state.headers.map((_, i) => (r[i] || '').trim()));
 
-            const lc = state.headers.map(h => h.toLowerCase());
-            const findIdx = (...keys) => {
-                for (const k of keys) {
-                    const i = lc.findIndex(h => h.includes(k));
-                    if (i !== -1) return i;
-                }
-                return -1;
-            };
-            state.map.title = Math.max(0, findIdx('title', 'name', 'product'));
-            state.map.price = findIdx('price', 'cost');
-            state.map.footer = findIdx('origin', 'source', 'note');
+            FIELDS.forEach(f => {
+                state.map[f.id] = findHeaderIndex(state.headers, f.aliases);
+            });
 
             buildMappingUI();
             document.getElementById('mappingPanel').hidden = false;
@@ -434,25 +483,25 @@
         }
 
         function buildMappingUI() {
-            ['mapTitle', 'mapPrice', 'mapFooter'].forEach(id => {
-                const select = document.getElementById(id);
+            FIELDS.forEach(f => {
+                const select = document.getElementById(f.selectId);
                 select.innerHTML = '';
-                if (id !== 'mapTitle') {
-                    const opt = document.createElement('option');
-                    opt.value = -1;
-                    opt.textContent = '— none —';
-                    select.appendChild(opt);
-                }
+                const none = document.createElement('option');
+                none.value = -1;
+                none.textContent = '— none —';
+                select.appendChild(none);
                 state.headers.forEach((h, i) => {
                     const opt = document.createElement('option');
                     opt.value = i;
                     opt.textContent = h;
                     select.appendChild(opt);
                 });
+                select.value = state.map[f.id];
+                select.addEventListener('change', () => {
+                    state.map[f.id] = parseInt(select.value, 10);
+                    render();
+                });
             });
-            document.getElementById('mapTitle').value = state.map.title;
-            document.getElementById('mapPrice').value = state.map.price;
-            document.getElementById('mapFooter').value = state.map.footer;
         }
 
         function computeLayout() {
@@ -463,30 +512,54 @@
             const usableW = page.w - margin * 2;
             const usableH = page.h - margin * 2;
             const cols = Math.max(1, Math.floor((usableW + gutter) / (CARD_W_MM + gutter)));
-            const rows = Math.max(1, Math.floor((usableH + gutter) / (CARD_H_MM + gutter)));
-            const perPage = cols * rows;
+            const rowsCount = Math.max(1, Math.floor((usableH + gutter) / (CARD_H_MM + gutter)));
+            const perPage = cols * rowsCount;
             const blockW = cols * CARD_W_MM + (cols - 1) * gutter;
-            const blockH = rows * CARD_H_MM + (rows - 1) * gutter;
+            const blockH = rowsCount * CARD_H_MM + (rowsCount - 1) * gutter;
             const offsetX = (page.w - blockW) / 2;
             const offsetY = (page.h - blockH) / 2;
-            return { page, margin, gutter, cols, rows, perPage, offsetX, offsetY };
+            return { page, margin, gutter, cols, rows: rowsCount, perPage, offsetX, offsetY };
         }
 
-        function cardFieldsFromRow(row) {
-            const { title: ti, price: pi, footer: fi } = state.map;
-            const title = ti >= 0 ? row[ti] : '';
-            const price = pi >= 0 ? row[pi] : '';
-            const footer = fi >= 0 ? row[fi] : '';
-            const used = new Set([ti, pi, fi].filter(i => i >= 0));
-            const extras = [];
-            for (let i = 0; i < state.headers.length; i++) {
-                if (used.has(i)) continue;
-                const val = row[i];
-                if (!val) continue;
-                extras.push({ key: state.headers[i], val });
-            }
-            return { title, price, footer, extras };
+        function cellFor(row, fieldId) {
+            const idx = state.map[fieldId];
+            if (idx < 0 || idx >= row.length) return '';
+            return unescapeNewlines(row[idx]);
         }
+
+        // Build a card DOM node for the on-screen preview.
+        function buildCardElement(row) {
+            const card = document.createElement('div');
+            card.className = 'card';
+
+            const bg = document.createElement('img');
+            bg.className = 'card-bg';
+            bg.src = BG_URL;
+            bg.alt = '';
+            card.appendChild(bg);
+
+            const fields = [
+                { cls: 'title center',          val: cellFor(row, 'title') },
+                { cls: 'english-title center',  val: cellFor(row, 'englishTitle') },
+                { cls: 'cn-ingredients center', val: cellFor(row, 'cnIngredients') },
+                { cls: 'en-ingredients center', val: cellFor(row, 'enIngredients') },
+                { cls: 'allergens',             val: cellFor(row, 'allergens') },
+                { cls: 'price',                 val: cellFor(row, 'price') },
+            ];
+            fields.forEach(({ cls, val }) => {
+                if (!val) return;
+                const el = document.createElement('div');
+                el.className = 'card-text ' + cls;
+                el.textContent = val;
+                card.appendChild(el);
+            });
+            return card;
+        }
+
+        // Page preview uses a CSS zoom factor so a full A3 fits on most monitors but
+        // the cards themselves are sized in physical mm — the same coordinate
+        // system the native PDF pipeline uses.
+        const PREVIEW_ZOOM = 0.7;
 
         function render() {
             const pagesEl = document.getElementById('pages');
@@ -500,12 +573,12 @@
             document.getElementById('layoutSummary').textContent =
                 `Cards: ${state.rows.length} · ${layout.cols}×${layout.rows} per page · Pages: ${totalPages}`;
 
-            const PX_PER_MM = 3; // preview scale
             for (let p = 0; p < totalPages; p++) {
                 const pageEl = document.createElement('div');
                 pageEl.className = 'page';
-                pageEl.style.width = layout.page.w * PX_PER_MM + 'px';
-                pageEl.style.height = layout.page.h * PX_PER_MM + 'px';
+                pageEl.style.width = layout.page.w + 'mm';
+                pageEl.style.height = layout.page.h + 'mm';
+                pageEl.style.zoom = PREVIEW_ZOOM;
 
                 const label = document.createElement('div');
                 label.className = 'page-label';
@@ -516,143 +589,202 @@
                     const dataIdx = p * layout.perPage + i;
                     if (dataIdx >= state.rows.length) break;
                     const col = i % layout.cols;
-                    const row = Math.floor(i / layout.cols);
+                    const rowIdx = Math.floor(i / layout.cols);
                     const x = layout.offsetX + col * (CARD_W_MM + layout.gutter);
-                    const y = layout.offsetY + row * (CARD_H_MM + layout.gutter);
+                    const y = layout.offsetY + rowIdx * (CARD_H_MM + layout.gutter);
 
-                    const cardEl = document.createElement('div');
-                    cardEl.className = 'card';
-                    cardEl.style.left = x * PX_PER_MM + 'px';
-                    cardEl.style.top = y * PX_PER_MM + 'px';
-                    cardEl.style.width = CARD_W_MM * PX_PER_MM + 'px';
-                    cardEl.style.height = CARD_H_MM * PX_PER_MM + 'px';
-
-                    const f = cardFieldsFromRow(state.rows[dataIdx]);
-                    if (f.title) {
-                        const t = document.createElement('div');
-                        t.className = 'title';
-                        t.textContent = f.title;
-                        cardEl.appendChild(t);
-                    }
-                    if (f.price) {
-                        const pr = document.createElement('div');
-                        pr.className = 'price';
-                        pr.textContent = f.price;
-                        cardEl.appendChild(pr);
-                    }
-                    if (f.extras.length) {
-                        const body = document.createElement('div');
-                        body.className = 'fields';
-                        f.extras.forEach(({ key, val }) => {
-                            const r = document.createElement('div');
-                            r.className = 'row-item';
-                            r.innerHTML = '<span class="key">' + escapeHtml(key) + ':</span> ' + escapeHtml(val);
-                            body.appendChild(r);
-                        });
-                        cardEl.appendChild(body);
-                    }
-                    if (f.footer) {
-                        const ft = document.createElement('div');
-                        ft.className = 'footer';
-                        ft.textContent = f.footer;
-                        cardEl.appendChild(ft);
-                    }
-
+                    const cardEl = buildCardElement(state.rows[dataIdx]);
+                    cardEl.style.left = x + 'mm';
+                    cardEl.style.top = y + 'mm';
+                    cardEl.style.width = CARD_W_MM + 'mm';
+                    cardEl.style.height = CARD_H_MM + 'mm';
                     pageEl.appendChild(cardEl);
                 }
                 pagesEl.appendChild(pageEl);
             }
         }
 
-        function escapeHtml(s) {
-            return String(s)
-                .replace(/&/g, '&amp;')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;');
+        // ===================== PDF pipeline (native, CMYK) =====================
+        // We bypass html2canvas and draw text natively in jsPDF so we can set CMYK
+        // colors. The background image is embedded as PNG (RGB) — if you need a
+        // fully CMYK PDF including the background, upload a CMYK-encoded JPEG to
+        // BG_CMYK_URL on S3 and we'll use that instead.
+
+        // #fbf6ed converted to CMYK (0–100 percent). Computed once, used per-card.
+        // R=251 G=246 B=237 → K≈1.6, C=0, M≈1.9, Y≈5.6.
+        const CARD_TEXT_CMYK = [0, 1.9, 5.6, 1.6];
+
+        const PDF_FIELDS = [
+            { id: 'title',         x: 'center', y: 23, size: 10, align: 'center', baseline: 'top' },
+            { id: 'englishTitle',  x: 'center', y: 30, size: 10, align: 'center', baseline: 'top' },
+            { id: 'cnIngredients', x: 'center', y: 42, size: 9,  align: 'center', baseline: 'top' },
+            { id: 'enIngredients', x: 'center', y: 49, size: 9,  align: 'center', baseline: 'top' },
+            { id: 'allergens',     x: 5.5,      y: 60, size: 9,  align: 'left',   baseline: 'top', maxWidth: 70 },
+            { id: 'price',         x: 82,       y: 60, size: 14, align: 'left',   baseline: 'top' },
+        ];
+
+        // Cache the font + background between PDF generations.
+        let cachedFontBase64 = null;
+        let cachedBgPngDataUrl = null;
+        let cachedCmykBgJpegDataUrl = null;  // set if BG_CMYK_URL is reachable
+
+        const PDF_FONT_NAME = 'ChocolateClassicalSans';
+        const PDF_FONT_FILE = 'ChocolateClassicalSans-Regular.ttf';
+        // Full unsubsetted TTF from the google/fonts repo — includes CJK glyphs.
+        const PDF_FONT_URL = 'https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/chocolateclassicalsans/ChocolateClassicalSans-Regular.ttf';
+
+        async function fetchAsBase64(url) {
+            const resp = await fetch(url);
+            if (!resp.ok) throw new Error(url + ' → HTTP ' + resp.status);
+            const buf = await resp.arrayBuffer();
+            const bytes = new Uint8Array(buf);
+            let binary = '';
+            const chunk = 0x8000;
+            for (let i = 0; i < bytes.length; i += chunk) {
+                binary += String.fromCharCode.apply(null, bytes.subarray(i, Math.min(i + chunk, bytes.length)));
+            }
+            return btoa(binary);
         }
 
-        function generatePDF() {
+        async function loadCardFont() {
+            if (cachedFontBase64) return cachedFontBase64;
+            setStatus('Loading Chocolate Classical Sans for PDF…');
+            cachedFontBase64 = await fetchAsBase64(PDF_FONT_URL);
+            return cachedFontBase64;
+        }
+
+        // Load a cross-origin image with CORS enabled, then re-encode via canvas.
+        // Requires the host (S3 in our case) to send Access-Control-Allow-Origin;
+        // otherwise the canvas will taint and toDataURL throws SecurityError.
+        function loadCorsImage(src, mimeType) {
+            return new Promise((resolve, reject) => {
+                const img = new Image();
+                img.crossOrigin = 'anonymous';
+                img.onload = () => {
+                    try {
+                        const canvas = document.createElement('canvas');
+                        canvas.width = img.naturalWidth;
+                        canvas.height = img.naturalHeight;
+                        canvas.getContext('2d').drawImage(img, 0, 0);
+                        resolve(canvas.toDataURL(mimeType || 'image/png'));
+                    } catch (e) {
+                        const err = new Error('CORS not configured for ' + src + ' — canvas tainted.');
+                        err.cause = e;
+                        reject(err);
+                    }
+                };
+                img.onerror = () => reject(new Error('Failed to load ' + src + ' (network error or CORS preflight rejected).'));
+                img.src = src;
+            });
+        }
+
+        // Optional CMYK JPEG override fetched with raw bytes (preserves the CMYK
+        // colour space; canvas re-encoding would convert it to RGB).
+        async function loadCmykBackgroundOverride() {
+            try {
+                const resp = await fetch(BG_CMYK_URL);
+                if (!resp.ok) return null;
+                const buf = await resp.arrayBuffer();
+                const bytes = new Uint8Array(buf);
+                let binary = '';
+                const chunk = 0x8000;
+                for (let i = 0; i < bytes.length; i += chunk) {
+                    binary += String.fromCharCode.apply(null, bytes.subarray(i, Math.min(i + chunk, bytes.length)));
+                }
+                return 'data:image/jpeg;base64,' + btoa(binary);
+            } catch (e) {
+                return null;
+            }
+        }
+
+        let bgInitDone = false;
+        async function loadCardBackground() {
+            if (bgInitDone) return { png: cachedBgPngDataUrl, cmyk: cachedCmykBgJpegDataUrl };
+            cachedCmykBgJpegDataUrl = await loadCmykBackgroundOverride();
+            cachedBgPngDataUrl = await loadCorsImage(BG_URL, 'image/png');
+            bgInitDone = true;
+            return { png: cachedBgPngDataUrl, cmyk: cachedCmykBgJpegDataUrl };
+        }
+
+        function drawCardNative(doc, cardX, cardY, row, bg) {
+            // Background fills the whole card.
+            if (bg.cmyk) {
+                doc.addImage(bg.cmyk, 'JPEG', cardX, cardY, CARD_W_MM, CARD_H_MM, undefined, 'NONE');
+            } else {
+                doc.addImage(bg.png, 'PNG', cardX, cardY, CARD_W_MM, CARD_H_MM, undefined, 'NONE');
+            }
+
+            // CMYK text on top.
+            doc.setFont(PDF_FONT_NAME, 'normal');
+            doc.setTextColor.apply(doc, CARD_TEXT_CMYK);
+
+            const cardCenterX = cardX + CARD_W_MM / 2;
+            PDF_FIELDS.forEach(f => {
+                const text = cellFor(row, f.id);
+                if (!text) return;
+                doc.setFontSize(f.size);
+                const tx = (f.x === 'center') ? cardCenterX : (cardX + f.x);
+                const ty = cardY + f.y;
+                let lines;
+                if (f.maxWidth) {
+                    // splitTextToSize honours existing \n and wraps long lines.
+                    lines = doc.splitTextToSize(text, f.maxWidth);
+                } else {
+                    lines = text.split('\n');
+                }
+                doc.text(lines, tx, ty, { align: f.align, baseline: f.baseline });
+            });
+        }
+
+        async function generatePDF() {
             if (!state.rows.length) return;
+            const btn = document.getElementById('generatePdfBtn');
+            btn.disabled = true;
             const layout = computeLayout();
             const { jsPDF } = window.jspdf;
             const doc = new jsPDF({
                 orientation: layout.page.jsOrientation,
                 unit: 'mm',
                 format: layout.page.jsFormat,
+                compress: true,
             });
 
-            const totalPages = Math.ceil(state.rows.length / layout.perPage);
-            for (let p = 0; p < totalPages; p++) {
-                if (p > 0) doc.addPage();
-                for (let i = 0; i < layout.perPage; i++) {
-                    const dataIdx = p * layout.perPage + i;
-                    if (dataIdx >= state.rows.length) break;
-                    const col = i % layout.cols;
-                    const rowIdx = Math.floor(i / layout.cols);
-                    const x = layout.offsetX + col * (CARD_W_MM + layout.gutter);
-                    const y = layout.offsetY + rowIdx * (CARD_H_MM + layout.gutter);
-                    drawCardPDF(doc, x, y, state.rows[dataIdx]);
-                }
-            }
-            doc.save('product-cards.pdf');
-            setStatus(`Exported ${state.rows.length} cards to product-cards.pdf.`);
-        }
+            try {
+                const [fontB64, bg] = await Promise.all([loadCardFont(), loadCardBackground()]);
+                doc.addFileToVFS(PDF_FONT_FILE, fontB64);
+                doc.addFont(PDF_FONT_FILE, PDF_FONT_NAME, 'normal');
 
-        function drawCardPDF(doc, x, y, row) {
-            const padX = 4;
-            const padY = 3;
-            const innerW = CARD_W_MM - padX * 2;
-            doc.setDrawColor(208, 212, 218);
-            doc.setLineWidth(0.3);
-            doc.rect(x, y, CARD_W_MM, CARD_H_MM);
+                const totalPages = Math.ceil(state.rows.length / layout.perPage);
+                for (let p = 0; p < totalPages; p++) {
+                    if (p > 0) doc.addPage();
+                    for (let i = 0; i < layout.perPage; i++) {
+                        const dataIdx = p * layout.perPage + i;
+                        if (dataIdx >= state.rows.length) break;
+                        const col = i % layout.cols;
+                        const rowIdx = Math.floor(i / layout.cols);
+                        const x = layout.offsetX + col * (CARD_W_MM + layout.gutter);
+                        const y = layout.offsetY + rowIdx * (CARD_H_MM + layout.gutter);
 
-            const f = cardFieldsFromRow(row);
-            let cursorY = y + padY + 4;
-
-            if (f.title) {
-                doc.setFont('helvetica', 'bold');
-                doc.setFontSize(12);
-                doc.setTextColor(26, 26, 46);
-                const titleLines = doc.splitTextToSize(f.title, innerW);
-                doc.text(titleLines.slice(0, 2), x + padX, cursorY);
-                cursorY += Math.min(titleLines.length, 2) * 4.6;
-            }
-            if (f.price) {
-                doc.setFont('helvetica', 'bold');
-                doc.setFontSize(13);
-                doc.setTextColor(185, 28, 28);
-                doc.text(f.price, x + padX, cursorY + 1);
-                cursorY += 5.5;
-            }
-
-            if (f.extras.length) {
-                doc.setFont('helvetica', 'normal');
-                doc.setFontSize(7.5);
-                doc.setTextColor(68, 68, 68);
-                const bottomLimit = y + CARD_H_MM - padY - (f.footer ? 5 : 1);
-                for (const { key, val } of f.extras) {
-                    if (cursorY > bottomLimit) break;
-                    const text = key + ': ' + val;
-                    const lines = doc.splitTextToSize(text, innerW);
-                    for (const line of lines) {
-                        if (cursorY > bottomLimit) break;
-                        doc.text(line, x + padX, cursorY);
-                        cursorY += 3.1;
+                        setStatus(`Drawing card ${dataIdx + 1} / ${state.rows.length}…`);
+                        drawCardNative(doc, x, y, state.rows[dataIdx], bg);
                     }
-                    cursorY += 0.4;
+                    // Yield to the UI between pages so the status text updates.
+                    await new Promise(r => setTimeout(r, 0));
                 }
-            }
-
-            if (f.footer) {
-                doc.setDrawColor(208, 212, 218);
-                doc.setLineDashPattern([0.6, 0.6], 0);
-                const lineY = y + CARD_H_MM - padY - 3.2;
-                doc.line(x + padX, lineY, x + CARD_W_MM - padX, lineY);
-                doc.setLineDashPattern([], 0);
-                doc.setFont('helvetica', 'normal');
-                doc.setFontSize(6.5);
-                doc.setTextColor(136, 136, 136);
-                doc.text(f.footer, x + padX, y + CARD_H_MM - padY);
+                doc.save('product-cards.pdf');
+                const cmykNote = bg.cmyk ? 'Full CMYK (text + background).' : 'CMYK text on RGB background (upload a CMYK JPEG to BG_CMYK_URL for full CMYK).';
+                setStatus(`Exported ${state.rows.length} cards to product-cards.pdf. ${cmykNote}`);
+            } catch (err) {
+                console.error(err);
+                const looksLikeCors = err && /tainted|toDataURL|CORS|preflight/i.test(err.message || String(err));
+                let msg = 'PDF generation failed: ' + (err && err.message ? err.message : err);
+                if (looksLikeCors) {
+                    document.getElementById('corsBanner').hidden = false;
+                    msg = 'PDF generation blocked — S3 bucket missing CORS headers. See banner at top of page for the JSON to paste into the bucket’s CORS configuration.';
+                }
+                setStatus(msg, true);
+            } finally {
+                btn.disabled = false;
             }
         }
 
@@ -683,16 +815,34 @@
         document.getElementById('loadSampleBtn').addEventListener('click', () => ingestCSV(SAMPLE_CSV));
         document.getElementById('generatePdfBtn').addEventListener('click', generatePDF);
 
+        // Probe S3 CORS up-front so we can show a clear banner before the user
+        // clicks "Generate PDF" and hits a SecurityError.
+        (function probeBgCors() {
+            const img = new Image();
+            img.crossOrigin = 'anonymous';
+            img.onload = () => { /* CORS OK */ };
+            img.onerror = () => {
+                document.getElementById('corsBanner').hidden = false;
+                console.warn('[card-printer] Background image CORS check failed — see banner.');
+            };
+            img.src = BG_URL + '?cors-probe=' + Date.now();
+        })();
+
+        // Kick off font loading immediately so the preview renders in the correct
+        // font and the first PDF export does not wait on the CJK subset.
+        ensureFontLoaded().then(() => {
+            if (isFontAvailable()) {
+                console.log(`[card-printer] "${FONT_FAMILY}" loaded.`);
+            } else {
+                console.warn(`[card-printer] "${FONT_FAMILY}" reported unloaded after fonts.ready — check network / CSP.`);
+            }
+            // Re-render any preview already on screen so it picks up the freshly
+            // loaded font instead of the fallback.
+            if (state.rows.length) render();
+        });
+
         ['pageFormat', 'margin', 'gutter'].forEach(id => {
             document.getElementById(id).addEventListener('input', render);
-        });
-        ['mapTitle', 'mapPrice', 'mapFooter'].forEach(id => {
-            document.getElementById(id).addEventListener('change', () => {
-                state.map.title = parseInt(document.getElementById('mapTitle').value, 10);
-                state.map.price = parseInt(document.getElementById('mapPrice').value, 10);
-                state.map.footer = parseInt(document.getElementById('mapFooter').value, 10);
-                render();
-            });
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary

Ships the Mamalili product-card template and the native-CMYK PDF pipeline for the card printer.

### What deploys
- **`product-card-printer/`** — full rewrite of the card layout to match the Mamalili design:
  - Chinese + English title and ingredients blocks (centered, top half)
  - Allergens bottom-left, price bottom-right at 14pt
  - All text `#fbf6ed` in Chocolate Classical Sans
  - Watercolor background loaded from S3 (`db-doc-tw1`)
- **PDF export** is now native jsPDF (no html2canvas): text rendered with `doc.setTextColor(0, 1.9, 5.6, 1.6)` for CMYK output, font TTF (~12 MB incl. CJK) embedded per export.
- **Optional full-CMYK background** via `BG_CMYK_URL` on S3 — auto-detected when reachable.
- In-app CORS probe + banner if the S3 bucket isn't configured to allow canvas reads.

### Asset choices
- Background image is hosted on S3, not in the repo (avoids 9.5 MB PNG in git).
- Local `product-card-printer/assets/` is gitignored implicitly (untracked).

## Test plan (post-deploy)

- [ ] Visit `https://joseph-tsai415.github.io/Yiling-Art/product-card-printer/`
- [ ] No red banner appears (S3 CORS is configured, which we already verified)
- [ ] Click **Load sample data** → preview renders 6 cards on A4 with the watercolor background
- [ ] Click **Generate PDF** → PDF downloads; status line says `CMYK text on RGB background…` (no CMYK JPEG override uploaded yet)
- [ ] Open the PDF, confirm text is in Chocolate Classical Sans, color matches `#fbf6ed`